### PR TITLE
Update Invoke-tSQLtTests.ps1 to resolve issue #13

### DIFF
--- a/buildAndReleaseTask/Invoke-tSQLtTests.ps1
+++ b/buildAndReleaseTask/Invoke-tSQLtTests.ps1
@@ -23,5 +23,5 @@ else {
     Write-Output "Tests ran successfully. Saving test results to $testResultsFileName"
 }
 
-Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName
+Invoke-SqlCmd -ConnectionString $connectionString -QueryTimeout $queryTimeout -InputFile ".\GetTestResults.sql" | Select-Object -ExpandProperty XML* | Out-File -FilePath $testResultsFileName -NoNewline
 Write-Output "Finished gathering test results and writing it to $testResultsFileName"


### PR DESCRIPTION
Adding the -NoNewline argument to Out-File when writing the test results prevents the extra new line characters from being inserted into the XML output and allows the results to be properly published.